### PR TITLE
Support Linux-Kernel_MiSTer build

### DIFF
--- a/repositories.ini
+++ b/repositories.ini
@@ -64,7 +64,7 @@ CORE_NAME="EpochGalaxyII"
 CORE_NAME="RX78"
 
 [Linux-Kernel_MiSTer]
-CORE_NAME="Linux-Kernel_MiSTer"
+CORE_NAME="zImage_dtb"
 DOCKER_IMAGE="theypsilon/gcc-arm:10.2-2020.11"
 COMPILATION_COMMAND="apt-get -y update \&\& apt-get -y install build-essential git libncurses-dev flex bison openssl libssl-dev dkms libelf-dev libudev-dev libpci-dev libiberty-dev autoconf liblz4-tool bc curl gcc git libssl-dev libncurses5-dev lzop make u-boot-tools libgmp3-dev libmpc-dev \&\& export ARCH=arm \&\& export LOCALVERSION=-MiSTer \&\& export CROSS_COMPILE=arm-none-linux-gnueabihf- \&\& make MiSTer_defconfig \&\& make -j2 zImage \&\& make socfpga_cyclone5_de10_nano.dtb \&\& cat arch/arm/boot/zImage arch/arm/boot/dts/socfpga_cyclone5_de10_nano.dtb > zImage_dtb"
 COMPILATION_OUTPUT="zImage_dtb"

--- a/repositories.ini
+++ b/repositories.ini
@@ -62,3 +62,9 @@ CORE_NAME="EpochGalaxyII"
 
 [RX-78_MiSTer]
 CORE_NAME="RX78"
+
+[Linux-Kernel_MiSTer]
+CORE_NAME="Linux-Kernel_MiSTer"
+DOCKER_IMAGE="theypsilon/gcc-arm:10.2-2020.11"
+COMPILATION_COMMAND="apt-get -y update \&\& apt-get -y install build-essential git libncurses-dev flex bison openssl libssl-dev dkms libelf-dev libudev-dev libpci-dev libiberty-dev autoconf liblz4-tool bc curl gcc git libssl-dev libncurses5-dev lzop make u-boot-tools libgmp3-dev libmpc-dev \&\& export ARCH=arm \&\& export LOCALVERSION=-MiSTer \&\& export CROSS_COMPILE=arm-none-linux-gnueabihf- \&\& make MiSTer_defconfig \&\& make -j2 zImage \&\& make socfpga_cyclone5_de10_nano.dtb \&\& cat arch/arm/boot/zImage arch/arm/boot/dts/socfpga_cyclone5_de10_nano.dtb > zImage_dtb"
+COMPILATION_OUTPUT="zImage_dtb"


### PR DESCRIPTION
This edit to `repositories.ini` adds support for building an unstable nightly of [Linux-Kernel_MiSTer](https://github.com/MiSTer-devel/Linux-Kernel_MiSTer). Since the kernel is rarely released, this can be helpful to get new features in the hands of users earlier.

- Here's a successful workflow run using this configuration: https://github.com/coolbho3k/Linux-Kernel_MiSTer/actions/runs/3310025629
- And the `zImage_dtb` built: https://github.com/coolbho3k/Linux-Kernel_MiSTer/releases/tag/unstable-builds

The kernel boots just fine on my MiSTer - to test, replace `/media/fat/linux/zImage_dtb` with the built kernel above. Everything seems to work on my forks, but _I can't currently test it fully with this project right now_, so I'll need some help to confirm that everything works with `MiSTer-unstable-nightlies`, including the repository sync stuff. It should work fine, though.

My fork of the kernel must be copied to the `MiSTer-unstable-nightlies` project to work: https://github.com/coolbho3k/Linux-Kernel_MiSTer/tree/automation_release - note that this is the `automation_release` branch on my fork of the repo. The changes are really simple, it just adds the default `ci_build.yml`.

A few notes:
- This uses the same Docker image by @theypsilon as the Main_MiSTer build, as it's convenient due to needing the same toolchain, and the build command installs additional dependencies for the kernel build. This is, of course, not the most efficient way to do things; we could also install dependencies in the Docker image instead.
- The version of GCC in the image is a bit old, too, so if we did that, maybe we can take the opportunity to refresh the toolchain as well.